### PR TITLE
Add deprecation banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,16 @@
             <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
 
+
+
         {% include header.html %}
         <main class="cd-main-content">
+            <div class="deprecation-banner">
+                <div class="deprecation-banner__content">
+                    This website is part of a finished project by the Open Knowledge Foundation Germany and is no longer being updated.
+                    The current legal notice and privacy policy can be found at <a href="https://okfn.de/impressum">okfn.de/impressum</a>.
+                </div>
+            </div>
             {{ content }}
 
             {% include footer.html %}

--- a/css/main.scss
+++ b/css/main.scss
@@ -24,3 +24,31 @@
     "colorbox",
     "docs"
 ;
+
+
+.deprecation-banner {
+    padding: 10px 30px;
+}
+
+.deprecation-banner__content {
+    border: 2px solid $medium-green;
+    padding: 10px;
+    padding-left: 25px;
+    position: relative;
+}
+
+.deprecation-banner__content:before {
+    content: "!";
+    position: absolute;
+    top: calc(50% - 15px);
+    left: -15px;
+    color: white;
+    background-color: $medium-green;
+    border-radius: 50%;
+    height: 30px;
+    width: 30px;
+    display: flex;
+    justify-content: center;
+    align-items:center;
+}
+


### PR DESCRIPTION
Opted for a version where the banner is not at the very top since that doesn't play well with the (mobile) navigation set up by bootstrap.

![CleanShot 2024-09-23 at 12 57 40@2x](https://github.com/user-attachments/assets/87adf401-a32b-422a-b04c-d9972476c159)
